### PR TITLE
Added getSolarIlluminationCycle endpoint

### DIFF
--- a/src/docs/api/Satellite.md
+++ b/src/docs/api/Satellite.md
@@ -61,6 +61,21 @@ Returns an array of `[enterInfo, exitInfo]`, with both being a dictionary of the
 
 This endpoint is for retrieving the next passes for the given week.
 
+##`/getSolarIlluminationCycle`
+Type: `GET`
+Request: `none`
+Response: `{ nextIlluminations }`
+
+Returns an array of `[enterInfo, exitInfo]`, with both being a dictionary of the form:
+`{
+    type: string,
+    time: string,
+    longitude: float,
+    latitude: float,
+}`. `type` can be "Enter" or "Exit", and time is a formatted human-readable time (i.e 9:00 AM)
+
+This endpoint is for retrieving the solar illumination cycles of a satellite for the given week. Only cycles of > 10 minutes are recorded to eliminate noise.
+
 ---
 
 # Database Endpoints

--- a/src/docs/api/Satellite.md
+++ b/src/docs/api/Satellite.md
@@ -24,7 +24,14 @@ Response: `{
     rangeSat
   }`
 
-Returns a dictionary of floats.
+Returns a dictionary of floats. The units are as follows:
+
+longitude : degrees
+latitude : degrees
+height : km
+azimuth : degrees
+elevation : degrees
+rangeSat: km
 
 This endpoint is for retrieving satellite information. Calculations are done through the `satellite.js` library based off TLE data, found [here](https://github.com/shashwatak/satellite-js). TLE data of a satellite can be found online, like on [n2yo](https://www.n2yo.com/database/?name=NEUDOSE#results).
 

--- a/src/leo-server-app/package-lock.json
+++ b/src/leo-server-app/package-lock.json
@@ -19,6 +19,7 @@
         "mongoose": "^8.0.0",
         "satellite.js": "^5.0.0",
         "spacetrack": "^2.1.3",
+        "suncalc": "^1.9.0",
         "util": "^0.12.5"
       },
       "devDependencies": {
@@ -6979,6 +6980,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
     },
     "node_modules/superagent": {
       "version": "8.1.2",

--- a/src/leo-server-app/package.json
+++ b/src/leo-server-app/package.json
@@ -20,6 +20,7 @@
     "mongoose": "^8.0.0",
     "satellite.js": "^5.0.0",
     "spacetrack": "^2.1.3",
+    "suncalc": "^1.9.0",
     "util": "^0.12.5"
   },
   "devDependencies": {

--- a/src/leo-server-app/src/routes/satellite.ts
+++ b/src/leo-server-app/src/routes/satellite.ts
@@ -290,7 +290,9 @@ router.get("/getSolarIlluminationCycle", (req: any, res: any) => {
         })
         .replace(/\u202f/g, " ");
 
+      // Checks if satellite is illuminated
       if (isSunlit(nextIlluminationTime, longitude, latitude, height)) {
+        // If satellite is entering illumniation, make a entry
         if (!enterIllumination) {
           enterInfo = {
             type: "Enter",
@@ -302,6 +304,7 @@ router.get("/getSolarIlluminationCycle", (req: any, res: any) => {
           enterTime = nextIlluminationTime.getTime();
         }
       } else {
+        // If satellite is exiting illumniation, make a exit, and push
         if (enterIllumination && enterTime !== null) {
           exitInfo = {
             type: "Exit",
@@ -310,6 +313,7 @@ router.get("/getSolarIlluminationCycle", (req: any, res: any) => {
             latitude: latitude,
           };
 
+          // Checks if the cycle > minimum cycle duration
           if (
             nextIlluminationTime.getTime() - enterTime >=
             MIN_CYCLE_DURATION

--- a/src/leo-server-app/src/routes/satellite.ts
+++ b/src/leo-server-app/src/routes/satellite.ts
@@ -318,21 +318,6 @@ router.get("/getSolarIlluminationCycle", (req: any, res: any) => {
   }
 });
 
-router.get("/testSun", (req: any, res: any) => {
-  try {
-    var d = new Date();
-    var satelliteInfo = getSatelliteInfo(d, tleLine1, tleLine2);
-    let longitude = satelliteInfo.longitude;
-    let latitude = satelliteInfo.latitude;
-    let height = satelliteInfo.height;
-    const sunTimes = SunCalc.getTimes(d, longitude, latitude, height / 1000);
-
-    res.json({ sunTimes });
-  } catch (error) {
-    res.status(500).json({ error: "Internal Server Error" });
-  }
-});
-
 router.post("/addSatelliteTarget", async (req: any, res: any) => {
   const { body } = req;
 

--- a/src/leo-server-app/src/routes/satellite.ts
+++ b/src/leo-server-app/src/routes/satellite.ts
@@ -102,6 +102,13 @@ function getSatelliteInfo(date: Date, tleLine1: string, tleLine2: string) {
 }
 
 function isSunlit(date: Date, lon: number, lat: number, height: number) {
+  if (isNaN(date.getTime())) {
+    throw new Error("Incorrect Date definition");
+  }
+  if (height > 2000) {
+    throw new Error("Height must be in km");
+  }
+
   const heightMeters = height * 1000; // Height from satellite.js are in km
   const sunTimes = SunCalc.getTimes(date, lat, lon, heightMeters);
 
@@ -109,8 +116,11 @@ function isSunlit(date: Date, lon: number, lat: number, height: number) {
   let sunlightEnd = new Date(
     (sunTimes.sunsetStart.getTime() + sunTimes.goldenHour.getTime()) / 2
   );
-  if (date > sunTimes.dawn && date < sunlightEnd) return true;
-  else return false;
+  if (date > sunTimes.dawn && date < sunlightEnd) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 router.get("/getSatelliteInfo", (req: any, res: any) => {

--- a/src/leo-server-app/src/tests/satellite.test.ts
+++ b/src/leo-server-app/src/tests/satellite.test.ts
@@ -1,6 +1,10 @@
 const request = require("supertest");
 const app = require("../app");
-const { getSatelliteInfo, setTleLines } = require("../routes/satellite");
+const {
+  getSatelliteInfo,
+  setTleLines,
+  isSunlit,
+} = require("../routes/satellite");
 
 let defaultTleLine1 =
     "1 55098U 23001CT  23359.66872105  .00021921  00000-0  89042-3 0  9991",
@@ -32,6 +36,20 @@ describe("getSatelliteInfo()", () => {
     await expect(() =>
       getSatelliteInfo(new Date("bad date"), defaultTleLine1, defaultTleLine2)
     ).toThrow();
+  });
+});
+
+describe("isSunlit()", () => {
+  test("Valid Input", async () => {
+    await expect(() => (new Date(), 0, 0, 0)).toBeDefined();
+  });
+
+  test("Invalid Date", async () => {
+    await expect(() => isSunlit(new Date("bad date"), 0, 0, 0)).toThrow();
+  });
+
+  test("Height in km", async () => {
+    await expect(() => isSunlit(new Date(), 0, 0, 2001)).toThrow();
   });
 });
 
@@ -104,6 +122,20 @@ describe("GET /getNextPasses", () => {
     setTleLines(defaultTleLine1, defaultTleLine2);
     await request(app)
       .get("/satellite/getNextPasses")
+      .expect("Content-Type", /json/)
+      .expect(200);
+  });
+  it("Throws error if invalid TLE", async () => {
+    setTleLines(null, null);
+    await request(app).get("/satellite/getNextPasses").expect(500);
+  });
+});
+
+describe("GET /getSolarIlluminationCycle", () => {
+  it("Responds with json", async () => {
+    setTleLines(defaultTleLine1, defaultTleLine2);
+    await request(app)
+      .get("/satellite/getSolarIlluminationCycle")
       .expect("Content-Type", /json/)
       .expect(200);
   });

--- a/src/leo-server-app/yarn.lock
+++ b/src/leo-server-app/yarn.lock
@@ -4183,6 +4183,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+suncalc@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz"
+  integrity sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==
+
 superagent@^8.0.5:
   version "8.1.2"
   resolved "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz"


### PR DESCRIPTION
Added satellite/getSolarIlluminationCycle endpoint to track solar illumination cycles of a satellite, for which it is lit for more than 10 minutes (to eliminate noise)

Relevant: #62, #68 