### PR TITLE
Added FuturePasses Styling

### DIFF
--- a/src/leo-client-app/src/components/FuturePasses.tsx
+++ b/src/leo-client-app/src/components/FuturePasses.tsx
@@ -1,18 +1,12 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
 import {
   Box,
+  Card,
+  CardContent,
   CircularProgress,
-  Link,
-  Paper,
+  Grid,
   Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
 } from "@mui/material";
-import { Card, CardContent, Grid } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import NextLink from "next/link";
 import axios from "axios";

--- a/src/leo-client-app/src/components/FuturePasses.tsx
+++ b/src/leo-client-app/src/components/FuturePasses.tsx
@@ -12,11 +12,13 @@ import {
   TableHead,
   TableRow,
 } from "@mui/material";
+import { Card, CardContent, Grid } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import NextLink from "next/link";
 import axios from "axios";
 import "../styles.css";
 import "./styles/component.css";
+import "./styles/futurePasses.css";
 
 interface Pass {
   type: string;
@@ -28,6 +30,32 @@ interface Pass {
 type Props = {
   noradId: string;
 };
+
+// Helper functions to format date and time
+function formatDate(dateString: string) {
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  };
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, options);
+}
+
+function formatTimeRange(startTime: string, endTime: string) {
+  const startDate = new Date(startTime);
+  const endDate = new Date(endTime);
+
+  const startHours = startDate.getHours();
+  const startMinutes = startDate.getMinutes().toString().padStart(2, "0");
+  const endHours = endDate.getHours();
+  const endMinutes = endDate.getMinutes().toString().padStart(2, "0");
+
+  const formattedStartTime = startHours + ":" + startMinutes;
+  const formattedEndTime = endHours + ":" + endMinutes;
+
+  return `${formattedStartTime} - ${formattedEndTime}`;
+}
 
 const FuturePasses = ({ noradId }: Props) => {
   const [passes, setPasses] = useState<Pass[][]>([]);
@@ -70,71 +98,59 @@ const FuturePasses = ({ noradId }: Props) => {
   }, [noradId]);
 
   return (
-    <Stack alignItems="center" spacing={2}>
-      <h1>Next Week&apos;s Passes</h1>
-      {isLoading && (
-        <Box className="loadingBox">
-          <CircularProgress />
-        </Box>
-      )}
-      {!isLoading && (
-        <TableContainer
-          component={Paper}
-          sx={{ maxWidth: 650, background: "#40403fb0" }}
-        >
-          <Table aria-label="simple table">
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ color: "white !important" }} align="center">
-                  Entry
-                </TableCell>
-                <TableCell sx={{ color: "white !important" }} align="center">
-                  Exit
-                </TableCell>
-                <TableCell sx={{ color: "white !important" }} align="center">
-                  More Info
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {passes &&
-                passes?.map((passPair, index) => (
-                  <TableRow
-                    key={passPair[0].time + index}
-                    sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+    <div className="futurePasses">
+      <Stack alignItems="flex-start" spacing={1}>
+        <p className="headerBox">Next Week&apos;s Passes</p>
+        {isLoading ? (
+          <Box className="loadingBox">
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Grid className="futurePassesBox" container spacing={2}>
+            {" "}
+            {passes &&
+              passes.map((passPair, index) => (
+                <Grid item key={index}>
+                  {" "}
+                  <NextLink
+                    href={`/detailed-display/${noradId}/${encodeURIComponent(
+                      formatDateToISO(passPair[0].time)
+                    )}/${encodeURIComponent(
+                      formatDateToISO(passPair[1].time)
+                    )}`}
+                    passHref
                   >
-                    <TableCell
-                      sx={{ color: "white !important" }}
-                      align="center"
-                      component="th"
-                      scope="row"
+                    <Card
+                      sx={{
+                        minWidth: 150,
+                        margin: 0.5,
+                        backgroundColor:
+                          "var(--material-theme-sys-light-inverse-on-surface)",
+                        cursor: "pointer",
+                        borderRadius: 3,
+                      }}
                     >
-                      {passPair[0].type === "Enter" && <>{passPair[0].time}</>}
-                    </TableCell>
-                    <TableCell
-                      sx={{ color: "white !important" }}
-                      align="center"
-                    >
-                      {passPair[1].type === "Exit" && <>{passPair[1].time}</>}
-                    </TableCell>
-                    <TableCell sx={{ color: "white !important" }}>
-                      <NextLink
-                        href={`/detailed-display/${noradId}/${encodeURIComponent(
-                          formatDateToISO(passPair[0].time)
-                        )}/${encodeURIComponent(
-                          formatDateToISO(passPair[1].time)
-                        )}`}
-                      >
-                        <u>View Details</u>
-                      </NextLink>
-                    </TableCell>
-                  </TableRow>
-                ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
-    </Stack>
+                      <CardContent>
+                        <Stack spacing={0}>
+                          <p className="cardTitle">
+                            {formatDate(passPair[0].time)}
+                          </p>
+                          <p className="cardSubtitle">
+                            {formatTimeRange(
+                              passPair[0].time,
+                              passPair[1].time
+                            )}
+                          </p>
+                        </Stack>
+                      </CardContent>
+                    </Card>
+                  </NextLink>
+                </Grid>
+              ))}
+          </Grid>
+        )}
+      </Stack>
+    </div>
   );
 };
 

--- a/src/leo-client-app/src/components/FuturePasses.tsx
+++ b/src/leo-client-app/src/components/FuturePasses.tsx
@@ -15,6 +15,8 @@ import {
 import React, { useEffect, useState } from "react";
 import NextLink from "next/link";
 import axios from "axios";
+import "../styles.css";
+import "./styles/component.css";
 
 interface Pass {
   type: string;
@@ -71,21 +73,15 @@ const FuturePasses = ({ noradId }: Props) => {
     <Stack alignItems="center" spacing={2}>
       <h1>Next Week&apos;s Passes</h1>
       {isLoading && (
-        <Box
-          sx={{
-            width: "100%",
-            minHeight: "200px",
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-          }}>
+        <Box className="loadingBox">
           <CircularProgress />
         </Box>
       )}
       {!isLoading && (
         <TableContainer
           component={Paper}
-          sx={{ maxWidth: 650, background: "#40403fb0" }}>
+          sx={{ maxWidth: 650, background: "#40403fb0" }}
+        >
           <Table aria-label="simple table">
             <TableHead>
               <TableRow>
@@ -105,17 +101,20 @@ const FuturePasses = ({ noradId }: Props) => {
                 passes?.map((passPair, index) => (
                   <TableRow
                     key={passPair[0].time + index}
-                    sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+                    sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                  >
                     <TableCell
                       sx={{ color: "white !important" }}
                       align="center"
                       component="th"
-                      scope="row">
+                      scope="row"
+                    >
                       {passPair[0].type === "Enter" && <>{passPair[0].time}</>}
                     </TableCell>
                     <TableCell
                       sx={{ color: "white !important" }}
-                      align="center">
+                      align="center"
+                    >
                       {passPair[1].type === "Exit" && <>{passPair[1].time}</>}
                     </TableCell>
                     <TableCell sx={{ color: "white !important" }}>
@@ -124,7 +123,8 @@ const FuturePasses = ({ noradId }: Props) => {
                           formatDateToISO(passPair[0].time)
                         )}/${encodeURIComponent(
                           formatDateToISO(passPair[1].time)
-                        )}`}>
+                        )}`}
+                      >
                         <u>View Details</u>
                       </NextLink>
                     </TableCell>

--- a/src/leo-client-app/src/components/styles/futurePasses.css
+++ b/src/leo-client-app/src/components/styles/futurePasses.css
@@ -1,0 +1,21 @@
+.futurePassesBox {
+  border: 2px solid var(--material-theme-sys-light-on-primary);
+  border-radius: 15px;
+  padding: 0.5%;
+  margin-top: -10px;
+  width: auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 100%;
+}
+
+.cardTitle {
+  font-family: var(--material-themetitleLarge);
+  color: var(--material-theme-sys-light-on-surface);
+}
+
+.cardSubtitle {
+  font-family: var(--material-themetitleMedium);
+  color: var(--material-theme-sys-light-on-surface-variant);
+}

--- a/src/leo-client-app/src/components/styles/futurePasses.css
+++ b/src/leo-client-app/src/components/styles/futurePasses.css
@@ -9,6 +9,17 @@
   justify-content: center;
   max-width: 100%;
   justify-content: flex-start;
+  max-height: 300px; /* height for two rows of cards */
+  overflow-y: auto;
+
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Hide scrollbar for IE, Edge and Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 }
 
 .cardTitle {

--- a/src/leo-client-app/src/components/styles/futurePasses.css
+++ b/src/leo-client-app/src/components/styles/futurePasses.css
@@ -8,6 +8,7 @@
   flex-wrap: wrap;
   justify-content: center;
   max-width: 100%;
+  justify-content: flex-start;
 }
 
 .cardTitle {


### PR DESCRIPTION
![image](https://github.com/RishiVaya/Lower_Earth_Orbiters/assets/35006641/f1bb1b33-f148-4709-ab36-abeaa2d9d789)

Added styling for FuturePasses, to match Figma design. Users can scroll down to see all passes

