### PR TITLE
Fixed Card UI on home page

### DIFF
--- a/src/leo-client-app/src/components/FuturePasses.tsx
+++ b/src/leo-client-app/src/components/FuturePasses.tsx
@@ -100,7 +100,12 @@ const FuturePasses = ({ noradId }: Props) => {
             <CircularProgress />
           </Box>
         ) : (
-          <Grid className="futurePassesBox" container spacing={1}>
+          <Grid
+            className="futurePassesBox"
+            container
+            spacing={1}
+            justifyContent="center"
+          >
             {" "}
             {passes &&
               passes.map((passPair, index) => (

--- a/src/leo-client-app/src/components/FuturePasses.tsx
+++ b/src/leo-client-app/src/components/FuturePasses.tsx
@@ -100,7 +100,7 @@ const FuturePasses = ({ noradId }: Props) => {
             <CircularProgress />
           </Box>
         ) : (
-          <Grid className="futurePassesBox" container spacing={2}>
+          <Grid className="futurePassesBox" container spacing={1}>
             {" "}
             {passes &&
               passes.map((passPair, index) => (

--- a/src/leo-client-app/src/components/UpcomingSchedules.tsx
+++ b/src/leo-client-app/src/components/UpcomingSchedules.tsx
@@ -144,11 +144,16 @@ const UpcomingSchedules = ({ noradId }: Props) => {
                   <Card
                     sx={{
                       minWidth: 150,
+                      maxWidth: 150,
                       margin: 0.5,
                       backgroundColor:
                         "var(--material-theme-sys-light-inverse-on-surface)",
                       cursor: "pointer",
                       borderRadius: 3,
+                      minHeight: 150,
+                      maxHeight: 150,
+                      display: "flex",
+                      flexDirection: "column",
                     }}
                   >
                     <CardContent>
@@ -167,14 +172,19 @@ const UpcomingSchedules = ({ noradId }: Props) => {
                         <>
                           {scheduleCommands[schedule.id] &&
                           scheduleCommands[schedule.id].length > 0 ? (
-                            scheduleCommands[schedule.id].map(
-                              (commandObj: any, cmdIndex) => (
-                                // Render each command in a separate <p> tag
-                                <p key={cmdIndex} className="cardSubtitle">
-                                  {commandObj.command}
-                                </p>
-                              )
-                            )
+                            <>
+                              {scheduleCommands[schedule.id]
+                                .slice(0, 3)
+                                .map((commandObj: any, cmdIndex) => (
+                                  // Render each command in a separate <p> tag
+                                  <p key={cmdIndex} className="cardSubtitle">
+                                    {commandObj.command}
+                                  </p>
+                                ))}
+                              {scheduleCommands[schedule.id].length > 3 && (
+                                <p className="cardSubtitle">...</p>
+                              )}
+                            </>
                           ) : (
                             <p className="cardSubtitle">No commands</p>
                           )}


### PR DESCRIPTION
![image](https://github.com/RishiVaya/Lower_Earth_Orbiters/assets/35006641/39e092cd-b85d-49cb-a3a0-a3d051a70089)

Cards now have consistent sizing, with overfill becoming "..." for styling. Futurepasses cards also centered.